### PR TITLE
Use real youtube thumbnails from youtube-dl

### DIFF
--- a/script-opts/gallery_worker.conf
+++ b/script-opts/gallery_worker.conf
@@ -1,0 +1,13 @@
+# accepts a |-separated list of URL patterns which gallery.lua should thumbnail using youtube-dl.
+# The patterns are matched after the http(s):// part of the URL.
+#^ matches the beginning of the URL, $ matches its end, and you should use % before any of the characters ^$()%|,.[]*+-? to match that character.
+#
+#Examples
+#  will exclude any URL that starts with http://youtube.com or https://youtube.com:
+#     ytdl_exclude=^youtube%.com
+#  will exclude any URL that ends with .mkv or .mp4:
+#     ytdl_exclude=%.mkv$|%.mp4$
+#  See more lua patterns here: https://www.lua.org/manual/5.1/manual.html#5.4.1
+#
+#See also: ytdl_hook-exclude in mpv's manpage.
+ytdl_exclude=


### PR DESCRIPTION
gallery-thumbgen.lua checks to see if the input_path starts with
https?://.  If so, it uses youtube-dl to attempt to resolve a url to a
thumbnail (i.e. the thumbnail used on the website.)  This works for any
site for which youtube-dl can find thumbnails.

In the special case of a link to youtube proper, youtube-dl is not used
because it's slow.  Instead the URL is parsed to pull out the video ID
and a URL to the thumbnail for that particular ID is generated.  This is
much faster than waiting for youtube-dl, but perhaps more brittle.

If any of the above fails, then the original input_path is returned and
thumbnailing proceeds as usual.

![screen shot 2018-12-07 at 4 31 58 pm](https://user-images.githubusercontent.com/41033/49679090-bdb03600-fa80-11e8-849f-2bf270c229e7.png)