### PR TITLE
preserve (and optionally display) playlist titles

### DIFF
--- a/script-opts/gallery.conf
+++ b/script-opts/gallery.conf
@@ -78,6 +78,8 @@ background=0.1
 show_filename=yes
 strip_directory=yes
 strip_extension=yes
+# whether to show the playlist title of the current selection (overrides show_filename)
+show_title=yes
 # size of the text. The up-down margin will be expanded if needed
 text_size=28
 


### PR DESCRIPTION
playlists have an optional 'title' subproperty that is used, for
example, by ytdl_hook.lua.  This title subproperty of playlists is only
populated if present in the playlist file, so to preserve it I've
modified restore_playlist_and_select to create an M3U playlist in
memory.

I've also added a simple option to display these playlist titles instead
of filenames, which creates a nice UX when viewing youtube playlists.