### PR TITLE
Force with_mpv for archive:// thumbnails

### DIFF
--- a/scripts/gallery-thumbgen.lua
+++ b/scripts/gallery-thumbgen.lua
@@ -133,6 +133,10 @@ function thumbnail_command(input_path, width, height, take_thumbnail_at, output_
         input_path = ytdl_thumbnail_url(input_path)
     end
 
+    if input_path:find("archive://") == 1 then
+        with_mpv = true
+    end
+
 
     if not with_mpv then
         out = { "ffmpeg" }


### PR DESCRIPTION
mpv built with libarchive support addresses the contents of zip archives using `archive://` filenames, which can't be thumbnailed with ffmpeg.