### PR TITLE
fix mpv subprocess argument format for mpv 0.32

### DIFF
--- a/scripts/gallery-thumbgen.lua
+++ b/scripts/gallery-thumbgen.lua
@@ -180,17 +180,17 @@ function thumbnail_command(input_path, width, height, take_thumbnail_at, output_
             if not accurate then
                 add({ "--hr-seek=no"})
             end
-            add({ "--start", take_thumbnail_at })
+            add({ "--start="..take_thumbnail_at })
         end
         add({
             "--no-config", "--msg-level=all=no",
-            "--vf", "lavfi=[" .. vf .. ",format=bgra]",
-            "--audio", "no",
-            "--sub", "no",
-            "--frames", "1",
-            "--image-display-duration", "0",
-            "--of", "rawvideo", "--ovc", "rawvideo",
-            "--o", output_path
+            "--vf=lavfi=[" .. vf .. ",format=bgra]",
+            "--audio=no",
+            "--sub=no",
+            "--frames=1",
+            "--image-display-duration=0",
+            "--of=rawvideo", "--ovc=rawvideo",
+            "--o="..output_path
         })
     end
     return out


### PR DESCRIPTION
https://github.com/mpv-player/mpv/blob/master/DOCS/interface-changes.rst

```
--- mpv 0.32.0 ---
   - change behavior when using legacy option syntax with options that start
     with two dashes (``--`` instead of a ``-``). Now, using the recommended
     syntax is required for options starting with ``--``, which means an option
     value must be strictly passed after a ``=``, instead of as separate
     argument. For example, ``--log-file f.txt`` was previously accepted and
     behaved like ``--log-file=f.txt``, but now causes an error. Use of legacy
     syntax that is still supported now prints a deprecation warning.
```

¯\\_(ツ)_/¯