### PR TITLE
Dynamic thumbnail sizes via input.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ c script-message playlist-view-close; script-message contact-sheet-toggle
 ```
 To ensure that only one of the scripts is active at a time.
 
+You can change thumbnail sizes dynamically from input.conf with the following binding format:
+```
+[key] script-message playlist-change-size "(ww * wh <= 1921 * 1081) and {603, 339} or {952, 536}"
+```
+
 # Playlist-view flagging
 
 When the playlist-view is open, you can flag playlist entries (using `SPACE` by default). Flagged entries are indicated with a small frame. Then, when exiting mpv a text file will be created (default `./mpv_gallery_flagged`) containing the filenames of the flagged entries, one per line.

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -502,7 +502,6 @@ end
 
 function change_thumb_size(thumb_size)
     opts.thumbnail_size = thumb_size
-    msg.info('Yeet')
     set_overlays()
     set_geometries()
     if gallery.active then

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -120,44 +120,49 @@ gallery.config.text_size = opts.text_size
 gallery.too_small = function()
     stop()
 end
-gallery.item_to_overlay_path = function(index, item)
-    local filename = item.filename
-    local filename_hash = hash_cache[filename]
-    if filename_hash == nil then
-        filename_hash = string.sub(sha256(normalize_path(filename)), 1, 12)
-        hash_cache[filename] = filename_hash
+function set_overlays()
+    gallery.item_to_overlay_path = function(index, item)
+        local filename = item.filename
+        local filename_hash = hash_cache[filename]
+        if filename_hash == nil then
+            filename_hash = string.sub(sha256(normalize_path(filename)), 1, 12)
+            hash_cache[filename] = filename_hash
+        end
+        local thumb_filename = string.format("%s_%d_%d", filename_hash, gallery.geometry.thumbnail_size[1], gallery.geometry.thumbnail_size[2])
+        return utils.join_path(opts.thumbs_dir, thumb_filename)
     end
-    local thumb_filename = string.format("%s_%d_%d", filename_hash, gallery.geometry.thumbnail_size[1], gallery.geometry.thumbnail_size[2])
-    return utils.join_path(opts.thumbs_dir, thumb_filename)
-end
-gallery.item_to_thumbnail_params = function(index, item)
-    return item.filename, opts.take_thumbnail_at
-end
-gallery.item_to_border = function(index, item)
-    local flagged = flags[item.filename]
-    local selected = index == gallery.selection
-    if not flagged and not selected then
-        return opts.normal_border_size, opts.normal_border_color
-    elseif flagged and selected then
-        return opts.selected_border_size, opts.selected_flagged_border_color
-    elseif flagged then
-        return opts.flagged_border_size, opts.flagged_border_color
-    elseif selected then
-        return opts.selected_border_size, opts.selected_border_color
+    gallery.item_to_thumbnail_params = function(index, item)
+        return item.filename, opts.take_thumbnail_at
     end
-end
-gallery.item_to_text = function(index, item)
-    if not opts.show_text or index ~= gallery.selection then return "", false end
-    local f
-    if opts.show_title and item.title then
-        f = item.title
-    else
-        f = item.filename
-        if opts.strip_directory then
-            if ON_WINDOWS then
-                f = string.match(f, "([^\\/]+)$") or f
-            else
-                f = string.match(f, "([^/]+)$") or f
+    gallery.item_to_border = function(index, item)
+        local flagged = flags[item.filename]
+        local selected = index == gallery.selection
+        if not flagged and not selected then
+            return opts.normal_border_size, opts.normal_border_color
+        elseif flagged and selected then
+            return opts.selected_border_size, opts.selected_flagged_border_color
+        elseif flagged then
+            return opts.flagged_border_size, opts.flagged_border_color
+        elseif selected then
+            return opts.selected_border_size, opts.selected_border_color
+        end
+    end
+    gallery.item_to_text = function(index, item)
+        if not opts.show_text or index ~= gallery.selection then return "", false end
+        local f
+        if opts.show_title and item.title then
+            f = item.title
+        else
+            f = item.filename
+            if opts.strip_directory then
+                if ON_WINDOWS then
+                    f = string.match(f, "([^\\/]+)$") or f
+                else
+                    f = string.match(f, "([^/]+)$") or f
+                end
+            end
+            if opts.strip_extension then
+                f = string.match(f, "(.+)%.[^.]+$") or f
             end
         end
         if opts.strip_extension then
@@ -166,6 +171,7 @@ gallery.item_to_text = function(index, item)
     end
     return f, true
 end
+set_overlays()
 
 do
     local function increment_func(increment, clamp)
@@ -241,7 +247,7 @@ do
     end
 end
 
-do
+function set_geometries()
     local geometry_functions = loadstring(string.format([[
     return {
     function(ww, wh, gx, gy, gw, gh, sw, sh, tw, th)
@@ -336,6 +342,7 @@ do
         end
     end
 end
+set_geometries()
 
 function normalize_path(path)
     if string.find(path, "://") then
@@ -493,6 +500,18 @@ if opts.start_on_mpv_startup then
     mp.observe_property("osd-width", "number", autostart)
 end
 
+function change_thumb_size(thumb_size)
+    opts.thumbnail_size = thumb_size
+    msg.info('Yeet')
+    set_overlays()
+    set_geometries()
+    if gallery.active then
+        stop()
+        load_selection()
+        start()
+    end
+end
+
 -- workaround for mpv bug #6823
 mp.observe_property("playlist", "native", playlist_changed)
 
@@ -501,3 +520,5 @@ mp.add_key_binding(nil, "playlist-view-close", stop)
 mp.add_key_binding('g', "playlist-view-toggle", toggle)
 mp.add_key_binding(nil, "playlist-view-load-selection", load_selection)
 mp.add_key_binding(nil, "playlist-view-write-flag-file", write_flag_file)
+mp.add_key_binding(nil, "playlist-change-size", change_thumb_size)
+


### PR DESCRIPTION
Hey!

I have a 4K TV I use playlist view on, and I've realized if I'm going through certain folders, if the images I happen to browse are more vertical/horizontal at times, or for some reason I want to see each picture larger/smaller to browse through them faster, it comes in handy to be able to swap between thumbnail sizes on the fly.