### PR TITLE
Refresh the view when changing flags

### DIFF
--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -205,7 +205,7 @@ do
             else
                 flags[name] = nil
             end
-            -- TODO refresh ass
+            gallery:ass_show(true, false, false, false)
         end
     if opts.mouse_support then
         bindings["MBTN_LEFT"]  = function()


### PR DESCRIPTION
Changing the flag of the current item doesn't actually produce any visual indication that the change happened. Just running `gallery:ass_show(...)` is enough to fix this behavior.