### PR TITLE
add option to create thumbs_dir

### DIFF
--- a/script-opts/contact_sheet.conf
+++ b/script-opts/contact_sheet.conf
@@ -7,6 +7,9 @@
 #thumbs_dir=~/.mpv_thumbs_dir
 #generate_thumbnails_with_mpv=no
 
+# create thumbs_dir if it doesn't exist
+# mkdir_thumbs=yes
+
 gallery_position={ (ww - gw) / 2, (wh - gh) / 2}
 gallery_size={ 9 * ww / 10, 9 * wh / 10 }
 min_spacing={ 15, 15 }

--- a/script-opts/playlist_view.conf
+++ b/script-opts/playlist_view.conf
@@ -6,7 +6,7 @@
 # note that not all env vars get expanded, only '~' and 'APPDATA' do
 
 # create thumbs_dir if it doesn't exist
-mkdir_thumbs=yes
+# mkdir_thumbs=yes
 
 # use mpv instead of ffmpeg for thumbnail generation
 # slightly slower and does not support transparency, but does not require additional ffmpeg/ffprobe executables

--- a/script-opts/playlist_view.conf
+++ b/script-opts/playlist_view.conf
@@ -5,6 +5,9 @@
 #thumbs_dir=%APPDATA%\mpv\gallery-thumbs-dir
 # note that not all env vars get expanded, only '~' and 'APPDATA' do
 
+# create thumbs_dir if it doesn't exist
+mkdir_thumbs=yes
+
 # use mpv instead of ffmpeg for thumbnail generation
 # slightly slower and does not support transparency, but does not require additional ffmpeg/ffprobe executables
 # yes on Windows, no on other plateforms

--- a/scripts/contact-sheet.lua
+++ b/scripts/contact-sheet.lua
@@ -41,6 +41,7 @@ gallery.config.always_show_placeholders = false
 opts = {
     thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
+    mkdir_thumbs = false,
 
     --gallery_position = "{30, 30}",
     --gallery_size = "{tw + 4*sw, wh - 2*gy }",
@@ -117,7 +118,11 @@ function reload_config()
     end
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
-        msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
+        if opts.mkdir_thumbs then
+            os.execute("mkdir " .. thumbs_dir)
+        else
+            msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
+        end
     end
 
     compute_geometry = get_geometry_function()

--- a/scripts/contact-sheet.lua
+++ b/scripts/contact-sheet.lua
@@ -41,7 +41,7 @@ gallery.config.always_show_placeholders = false
 opts = {
     thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
-    mkdir_thumbs = false,
+    mkdir_thumbs = true,
 
     --gallery_position = "{30, 30}",
     --gallery_size = "{tw + 4*sw, wh - 2*gy }",

--- a/scripts/contact-sheet.lua
+++ b/scripts/contact-sheet.lua
@@ -119,7 +119,7 @@ function reload_config()
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
         if opts.mkdir_thumbs then
-            os.execute("mkdir " .. thumbs_dir)
+            utils.subprocess({ args = { "mkdir", thumbs_dir } })
         else
             msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
         end

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -39,7 +39,7 @@ gallery.config.accurate = false
 opts = {
     thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
-    mkdir_thumbs = false,
+    mkdir_thumbs = true,
 
     gallery_position = "{ (ww - gw) / 2, (wh - gh) / 2}",
     gallery_size = "{ 9 * ww / 10, 9 * wh / 10 }",

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -39,6 +39,7 @@ gallery.config.accurate = false
 opts = {
     thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
+    mkdir_thumbs = false,
 
     gallery_position = "{ (ww - gw) / 2, (wh - gh) / 2}",
     gallery_size = "{ 9 * ww / 10, 9 * wh / 10 }",
@@ -111,7 +112,11 @@ function reload_config()
     end
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
-        msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
+        if opts.mkdir_thumbs then
+            os.execute("mkdir " .. thumbs_dir)
+        else
+            msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
+        end
     end
 
     compute_geometry = get_geometry_function()

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -113,7 +113,7 @@ function reload_config()
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
         if opts.mkdir_thumbs then
-            os.execute("mkdir " .. thumbs_dir)
+            utils.subprocess({ args = { "mkdir", thumbs_dir } })
         else
             msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
         end


### PR DESCRIPTION
disabled by default. this will allow users who are using ramdisk as
thumbs_dir to not have to manually create that directory after every
reboot.

i had this hardcoded for myself for a good while, but i don't see why
this shouldn't be upstreamed.