### PR TITLE
Change Unix default thumbnail directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Playlist view and [contact sheet](https://en.wikipedia.org/wiki/Contact_print) s
 # Important
 
 * **Make sure that the thumbnail directory exists for thumbnail generation to work.**
-* **The default thumbnail directory is probably not appropriate for your system.** `~/.mpv_thumbs_dir/` on Unix, `%APPDATA%\mpv\gallery-thumbs-dir` on Windows. See Configuration for instructions on how to change it.
+* The default directories are: `~/.cache/thumbnails/mpv-gallery` on Unix, `%APPDATA%\mpv\gallery-thumbs-dir` on Windows. See Configuration for instructions on how to change it.
 
 # Installation
 
@@ -42,12 +42,12 @@ When the playlist-view is open, you can flag playlist entries (using `SPACE` by 
 
 Yet another ad-hoc thumbnail library, which is not shared with any other program.
 
-Management of the thumbnails is left to the user. In particular, stale thumbnails (whose file has been (re)moved) are not deleted by the script. This can be fixed by deleting thumbnails which have not been accessed since N days with such a snippet
+Management of the thumbnails is left to the user. In particular, stale thumbnails (whose file has been (re)moved) are not deleted by the script. This can be fixed by deleting thumbnails which have not been accessed since N days with such a snippet:
 ```
 days=7
 min=$((days * 60 * 24))
 # run first without -delete to be sure
-find ~/.mpv_thumbs_dir/ -maxdepth 1 -type f -amin +$min -delete
+find ~/.cache/thumbnails/mpv-gallery/ -maxdepth 1 -type f -amin +$min -delete
 ```
 
 Thumbnails are raw bgra, which is somewhat wasteful. With the default settings, a thumbnail uses 81KB (around 13k thumbnails in a GB).

--- a/script-opts/contact_sheet.conf
+++ b/script-opts/contact_sheet.conf
@@ -4,7 +4,7 @@
 #thumbs_dir=%APPDATA%\mpv\gallery-thumbs-dir
 #generate_thumbnails_with_mpv=yes
 # everywhere else:
-#thumbs_dir=~/.mpv_thumbs_dir
+#thumbs_dir=~/.cache/thumbnails/mpv-gallery
 #generate_thumbnails_with_mpv=no
 
 # create thumbs_dir if it doesn't exist

--- a/script-opts/playlist_view.conf
+++ b/script-opts/playlist_view.conf
@@ -1,6 +1,6 @@
 # thumbnail directory in which to create and look for thumbnails
 # on Unix-like platforms:
-#thumbs_dir=~/.mpv_thumbs_dir
+#thumbs_dir=~/.cache/thumbnails/mpv-gallery
 # on Windows:
 #thumbs_dir=%APPDATA%\mpv\gallery-thumbs-dir
 # note that not all env vars get expanded, only '~' and 'APPDATA' do

--- a/scripts/contact-sheet.lua
+++ b/scripts/contact-sheet.lua
@@ -39,7 +39,7 @@ gallery.config.align_text = false
 gallery.config.always_show_placeholders = false
 
 opts = {
-    thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
+    thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.cache/thumbnails/mpv-gallery/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
     mkdir_thumbs = true,
 

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -37,7 +37,7 @@ gallery.config.always_show_placeholders = true
 gallery.config.accurate = false
 
 opts = {
-    thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.mpv_thumbs_dir/",
+    thumbs_dir = ON_WINDOWS and "%APPDATA%\\mpv\\gallery-thumbs-dir" or "~/.cache/thumbnails/mpv-gallery/",
     generate_thumbnails_with_mpv = ON_WINDOWS,
     mkdir_thumbs = true,
 


### PR DESCRIPTION
This PR only changes the default Unix directory from `~/.mpv_thumbs_dir/` to `~/.cache/thumbnails/mpv-gallery`. The majority of graphical Linux systems in use store their thumbnails at `~/.cache/thumbnails/` and it makes sense to have a folder for this script their as well. Users who clean their thumbnail caches regularly probably don't have to adjust anything to clean this folder too.