### PR TITLE
Add move mode, shuffle, mpv config env, and option for playlist_view_toggle bind

### DIFF
--- a/script-opts/playlist_view.conf
+++ b/script-opts/playlist_view.conf
@@ -8,7 +8,7 @@
 #thumbs_dir=~/.cache/thumbnails/mpv-gallery
 # on Windows:
 #thumbs_dir=%APPDATA%\mpv\gallery-thumbs-dir
-# note that not all env vars get expanded, only '~' and 'APPDATA' do
+# note: not all env vars get expanded, only '~', 'APPDATA' and ':dir%mpvconf%' (':dir%mpvconf' is the mpv config directory) do
 
 # create thumbs_dir if it doesn't exist
 # mkdir_thumbs=yes
@@ -107,6 +107,7 @@ command_on_close=
 flagged_file_path=./mpv_gallery_flagged
 
 mouse_support=yes
+PLAYLIST_VIEW_TOGGLE=g
 UP=UP
 DOWN=DOWN
 LEFT=LEFT
@@ -116,8 +117,10 @@ PAGE_DOWN=PGDWN
 FIRST=HOME
 LAST=END
 RANDOM=r
+SHUFFLE=s
 ACCEPT=ENTER
 CANCEL=ESC
 # this only removes entries from the playlist, not the underlying file
 REMOVE=DEL
 FLAG=SPACE
+MODE_MOVE_TOGGLE=m


### PR DESCRIPTION
- Move mode enables you to move the selected item in the playlist, by default it is toggled with "m"
- Shuffle, shuffles the playlist and moves the playing item to the start, by default it is "s"
- Mpv config env `:/dir%mpvconf%`  to use the mpv config directory with `thumbs_dir` without writing out the full path
- Option for playlist_view_toggle bind so that it can be set inside `playlistview.conf`