### PR TITLE
fix: create directory recursively on Linux

### DIFF
--- a/scripts/contact-sheet.lua
+++ b/scripts/contact-sheet.lua
@@ -125,7 +125,8 @@ function reload_config()
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
         if opts.mkdir_thumbs then
-            utils.subprocess({ args = { "mkdir", thumbs_dir } })
+            local args = ON_WINDOWS and { "mkdir", thumbs_dir } or { "mkdir", "-p", thumbs_dir }
+            utils.subprocess({ args = args })
         else
             msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
         end

--- a/scripts/playlist-view.lua
+++ b/scripts/playlist-view.lua
@@ -119,7 +119,8 @@ function reload_config()
     local res = utils.file_info(thumbs_dir)
     if not res or not res.is_dir then
         if opts.mkdir_thumbs then
-            utils.subprocess({ args = { "mkdir", thumbs_dir } })
+            local args = ON_WINDOWS and { "mkdir", thumbs_dir } or { "mkdir", "-p", thumbs_dir }
+            utils.subprocess({ args = args })
         else
             msg.error(string.format("Thumbnail directory \"%s\" does not exist", thumbs_dir))
         end


### PR DESCRIPTION
Without `-p`, directory creation will fail on Linux on a fresh installation.